### PR TITLE
fixed dumping rpx/rpl file from disc

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -34,9 +34,9 @@ misrepresented as being the original software.
 #include "dynamic_libs/socket_functions.h"
 #include "net.h"
 
-#define MAX_NET_BUFFER_SIZE (60*1024)
+#define MAX_NET_BUFFER_SIZE (64*1024)
 #define MIN_NET_BUFFER_SIZE 4096
-#define FREAD_BUFFER_SIZE (60*1024)
+#define FREAD_BUFFER_SIZE (64*1024)
 
 extern u32 hostIpAddress;
 


### PR DESCRIPTION
The offset needs to be a mutiple of 0x10000 otherwise you'll get:
"ATFS atfs_security.c(405): __readDataBlocks() tried to access invalid offset in single hash section #23"